### PR TITLE
missing dependency

### DIFF
--- a/Untwister.cpp
+++ b/Untwister.cpp
@@ -17,6 +17,7 @@
 
 #include "Untwister.h"
 #include <iostream>
+#include <stdexcept>
 
 Untwister::Untwister()
 {


### PR DESCRIPTION
runtime_error missing dependency fixed

Example make error:
g++ -std=gnu++11 -O3 -g3 -Wall -c -fmessage-length=0 -MMD -fPIC -MF"prngs/GlibcRand.d" -MT"prngs/GlibcRand.d" -o "prngs/GlibcRand.o" "./prngs/GlibcRand.cpp"
g++ -std=gnu++11 -O3 -g3 -Wall -c -fmessage-length=0 -MMD -fPIC -MF"prngs/Mt19937.d" -MT"prngs/Mt19937.d" -o "prngs/Mt19937.o" "./prngs/Mt19937.cpp"
g++ -std=gnu++11 -O3 -g3 -Wall -c -fmessage-length=0 -MMD -fPIC -MF"prngs/PHP_mt19937.d" -MT"prngs/PHP_mt19937.d" -o "prngs/PHP_mt19937.o" "./prngs/PHP_mt19937.cpp"
g++ -std=gnu++11 -O3 -g3 -Wall -c -fmessage-length=0 -MMD -fPIC -MF"prngs/Ruby.d" -MT"prngs/Ruby.d" -o "prngs/Ruby.o" "./prngs/Ruby.cpp"
g++ -std=gnu++11 -O3 -g3 -Wall -c -fmessage-length=0 -MMD -fPIC -MF"prngs/LSBState.d" -MT"prngs/LSBState.d" -o "prngs/LSBState.o" "./prngs/LSBState.cpp"
g++ -std=gnu++11 -O3 -g3 -Wall -c -fmessage-length=0 -MMD -fPIC -MF"prngs/PRNGFactory.d" -MT"prngs/PRNGFactory.d" -o "prngs/PRNGFactory.o" "./prngs/PRNGFactory.cpp"
g++ -std=gnu++11 -O3 -g3 -Wall -c -fmessage-length=0 -MMD -fPIC -pthread -MF"Untwister.d" -MT"Untwister.d" -o "Untwister.o" "./Untwister.cpp"
./Untwister.cpp: In member function ‘std::vector<std::pair<unsigned int, double> > Untwister::bruteforce(uint32_t, uint32_t)’:
./Untwister.cpp:68:15: error: ‘runtime_error’ is not a member of ‘std’
./Untwister.cpp: In member function ‘State Untwister::inferState()’:
./Untwister.cpp:179:15: error: ‘runtime_error’ is not a member of ‘std’
./Untwister.cpp: In member function ‘std::vector<unsigned int>* Untwister::getStatus()’:
./Untwister.cpp:324:11: error: ‘runtime_error’ is not a member of ‘std’
./Untwister.cpp: In member function ‘void Untwister::setPRNG(std::string)’:
./Untwister.cpp:342:15: error: ‘runtime_error’ is not a member of ‘std’
./Untwister.cpp: In member function ‘std::vector<unsigned int>* Untwister::getStatus()’:
./Untwister.cpp:325:1: warning: control reaches end of non-void function [-Wreturn-type]
