### PR TITLE
Fixed timestamp bounds overwritten

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -395,12 +395,12 @@ int main(int argc, char *argv[])
         return EXIT_SUCCESS;
     }
     /* If it wasn't set manually, set the min seed */
-    if(!manualSeedMinFlag)
+    if(!(manualSeedMinFlag || timestampFlag))
     {
         lowerBoundSeed = untwister->getMinSeed();
     }
     /* If it wasn't set manually, set the max seed */
-    if(!manualSeedMaxFlag)
+    if(!(manualSeedMaxFlag || timestampFlag))
     {
         upperBoundSeed = untwister->getMaxSeed();
     }


### PR DESCRIPTION
Using the timestamp option `-u` resulted in brute force over the entire seed space because the min and max bounds were being overwritten based on the presence of manual bound flags